### PR TITLE
Investigation

### DIFF
--- a/RodizioSmartRestuarant/App.xaml.cs
+++ b/RodizioSmartRestuarant/App.xaml.cs
@@ -54,7 +54,7 @@ namespace RodizioSmartRestuarant
         {
             string folder = new SerializedObjectManager().savePath(Entities.Enums.Directories.Error);
 
-            string fileName = $"error_log[{DateTime.Now.ToString()}].txt";
+            string fileName = $"error_log.txt";
 
             // TODO: Have the smpt server send the error messages to our email, But we basically need to test if the line below works
             // SendErrorlogSMS(e.ExceptionObject.ToString());


### PR DESCRIPTION
Error was most likely caused by an online order which was incorrectly formatted and thus caused errors on deserialization.
(Looks like what actually happened is some orders from 04-08 and 05-08 got split into order items and some lacked the collected = true attribute so they got pushed to order and couldn't deserialize when the POS opened)

I edited the App.xaml.cs to see if the error log was causing an exception which was causing the rest of the code not to be executed and the email of the error log not to be sent.